### PR TITLE
Show WAVE fmt header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.d
+*.a
+*.so
+riffr-info

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ RIFFRLIB_SRC += riffr_read_chunk_header.c
 RIFFRLIB_SRC += riffr_read_chunk_body.c
 RIFFRLIB_SRC += riffr_get_chunk_type.c
 RIFFRLIB_SRC += riffr_read_data.c
+RIFFRLIB_SRC += riffr_filename.c
 
 
 RIFFRLIB_LDLIBS :=

--- a/riffr-info.c
+++ b/riffr-info.c
@@ -8,56 +8,195 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <stddef.h>
 #include "riffr.h"
+
+static int is_wave_fmt(const char *form_str,
+                       const char *chunk_str)
+{
+    return !strcmp(form_str, "WAVE") &&  !strcmp(chunk_str, "fmt ");
+}
+
+static void show_guid(const char *label, const uint8_t *guid, size_t len)
+{
+    printf("%s (%ld):", label, len);
+    while(len--) {
+        printf(" %02x", *guid++);
+    }
+    printf("\n");
+}
+
+/* 'len' may be larger, the same, or smaller than the size of 'fmt' */
+static void show_wave_fmt_data(struct riffr_wave_fmt *fmt, size_t len)
+{
+    if (len >= offsetof(struct riffr_wave_fmt, nChannels)) {
+        printf("wFormatTag: 0x%x\n", fmt->wFormatTag);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, nSamplesPerSec)) {
+        printf("nChannels: %d\n", fmt->nChannels);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, nAvgBytesPerSec)) {
+        printf("nSamplesPerSec: %d\n", fmt->nSamplesPerSec);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, nBlockAlign)) {
+        printf("nAvgBytesPerSec: %d\n", fmt->nAvgBytesPerSec);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, wBitsPerSample)) {
+        printf("nBlockAlign: %d\n", fmt->nBlockAlign);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, cbSize)) {
+        printf("wBitsPerSample: %d\n", fmt->wBitsPerSample);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, wValidBitsPerSample)) {
+        printf("cbSize: %d\n", fmt->cbSize);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, dwChannelMask)) {
+        printf("wValidBitsPerSample: %d\n", fmt->wValidBitsPerSample);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, SubFormat)) {
+        printf("dwChannelMask: 0x%08x\n", fmt->dwChannelMask);
+    }
+    if (len >= offsetof(struct riffr_wave_fmt, SubFormat)) {
+        size_t remaining = sizeof(*fmt);
+        remaining -= offsetof(struct riffr_wave_fmt, SubFormat);
+
+        show_guid("SubFormat", fmt->SubFormat, remaining);
+    }
+}
+
+/* 'len' may be larger, the same, or smaller than the size of 'fmt' */
+static int show_wave_fmt_leftover(struct riffr *handle,
+                                  const char *label,
+                                  size_t len)
+{
+    int err = -1;
+    int rc = 0;
+    int i = 0;
+    uint8_t data;
+    int outlen;
+
+    outlen = printf("%s (%ld):", label, len);
+    while (len--) {
+        rc = riffr_read_data(handle, "C", sizeof(data), &data);
+        if (rc < 0) {
+            err = rc;
+            break;
+        } else {
+            err = 0;
+        }
+        if (i == 8) {
+            printf("\n%*s", outlen, "");
+            i = 0;
+        }
+        printf(" %02x", data);
+        i++;
+    }
+    printf("\n");
+
+    return err;
+}
+
+static int show_wave_fmt(struct riffr *handle,
+                         struct riffr_chunk_header *header)
+{
+    int err = -1;
+    struct riffr_wave_fmt fmt;
+    int actual;
+
+    memset(&fmt, 0, sizeof(fmt));
+
+    /* Read as much of fmt as possible up to the size of the header. */
+    actual = riffr_read_data(handle,
+                             RIFFR_WAVE_FMT_FORMAT,
+                             header->size,
+                             &fmt);
+
+    if (actual > 0) {
+        ssize_t leftover;
+        leftover = header->size - actual;
+        show_wave_fmt_data(&fmt, actual);
+        if (leftover > 0) {
+            err = show_wave_fmt_leftover(handle, "More...", leftover);
+        }
+    } else {
+        err = -1;
+        fprintf(stderr,
+                "%s: Error handling WAVE fmt\n",
+                riffr_filename(handle));
+    }
+
+    return err;
+}
+
+static int show_chunk(struct riffr *handle,
+                      const char *form_str,
+                      struct riffr_chunk_header *header)
+{
+    int err = -1;
+    int rc = 0;
+    const char *str;
+    struct riffr_chunk_type type;
+    uint32_t list_form;
+    const char *file = riffr_filename(handle);
+
+    err = riffr_get_chunk_type(handle, header->id, &type);
+    if (err) {
+        fprintf(stderr, "%s: Error getting chunk type\n", file);
+        return err;
+    }
+    str = riffr_type_str(type);
+    printf("%s: %u\n", str, header->size);
+    if (!strcmp(str, "LIST")) {
+        /* LIST contains a type and is nested with more chunks. */
+        rc = riffr_read_data(handle,
+                              "D",
+                              sizeof(list_form), &list_form);
+        if (rc > 0) {
+            err = riffr_get_chunk_type(handle, list_form, &type);
+            if (err) {
+                fprintf(stderr, "%s: Error getting chunk type\n", file);
+                return err;
+            }
+            str = riffr_type_str(type);
+            printf("LIST: %s\n", str);
+        } else {
+            fprintf(stderr, "%s: Error handling LIST\n", file);
+            return -1;
+        }
+
+    } else if (is_wave_fmt(form_str, str)) {
+        show_wave_fmt(handle, header);
+    } else {
+        err = riffr_read_chunk_body(handle, header->size, NULL);
+        if (err) {
+            fprintf(stderr, "%s: Error skipping chunk body\n", file);
+            return -1;
+        }
+    }
+
+    return err;
+}
 
 static void riffr_info(const char *file)
 {
     struct riffr_chunk_header header;
-    struct riffr_chunk_type type;
     struct riffr_chunk_type form;
     struct riffr *handle;
-    uint32_t list_form;
+    const char *form_str = riffr_type_str(form);
     int err = -1;
 
     handle = riffr_open(file, "r", &form);
     if (handle) {
-        printf("%s: %s\n", file, riffr_type_str(form));
+        printf("%s: %s\n", file, form_str);
         for (;;) {
-            const char *str;
             err = riffr_read_chunk_header(handle, &header);
             if (err) {
+                /* Assume EOF */
                 break;
             }
-            err = riffr_get_chunk_type(handle, header.id, &type);
+            err = show_chunk(handle, form_str, &header);
             if (err) {
-                fprintf(stderr, "%s: Error getting chunk type\n", file);
                 break;
-            }
-            str = riffr_type_str(type);
-            printf("%s: %u\n", str, header.size);
-            if (!strcmp(str, "LIST")) {
-                /* LIST contains a type and is nested with more chunks. */
-                err = riffr_read_data(handle,
-                                      "D",
-                                      sizeof(list_form), &list_form);
-                if (!err) {
-                    err = riffr_get_chunk_type(handle, list_form, &type);
-                    if (err) {
-                        fprintf(stderr, "%s: Error getting chunk type\n", file);
-                        break;
-                    }
-                    str = riffr_type_str(type);
-                    printf("LIST: %s\n", str);
-                } else {
-                    fprintf(stderr, "%s: Error handling LIST\n", file);
-                    break;
-                }
-            } else {
-                err = riffr_read_chunk_body(handle, header.size, NULL);
-                if (err) {
-                    fprintf(stderr, "%s: Error skipping chunk body\n", file);
-                    break;
-                }
             }
         }
     } else {

--- a/riffr.h
+++ b/riffr.h
@@ -26,6 +26,28 @@ struct riffr_chunk_type {
     char str[RIFFR_TYPE_LEN];
 };
 
+/* WAVE fmt chunk */
+
+#define RIFFR_WAVE_FMT_GUID_LEN 16
+
+struct riffr_wave_fmt {
+    uint16_t wFormatTag;          /*  0 Format code                       */
+    uint16_t nChannels;           /*  2 Number of interleaved channels    */
+    uint32_t nSamplesPerSec;      /*  4 Sampling rate (blocks per second) */
+    uint32_t nAvgBytesPerSec;     /*  8 Data rate                         */
+    uint16_t nBlockAlign;         /* 12 Data block size (bytes)           */
+    uint16_t wBitsPerSample;      /* 14 Bits per sample                   */
+    uint16_t cbSize;              /* 16 Size of the extension             */
+    uint16_t wValidBitsPerSample; /* 18 Number of valid bits              */
+    uint32_t dwChannelMask;       /* 20 Speaker position mask             */
+                                  /* 24 GUID                              */
+    uint8_t  SubFormat[RIFFR_WAVE_FMT_GUID_LEN];
+};                                /* 40 (maximum) */
+
+#define RIFFR_WAVE_FMT_FORMAT_16 "WWDDWW"
+#define RIFFR_WAVE_FMT_FORMAT_18 RIFFR_WAVE_FMT_FORMAT_16 "W"
+#define RIFFR_WAVE_FMT_FORMAT RIFFR_WAVE_FMT_FORMAT_18 "WDG"
+
 extern struct riffr *riffr_open(const char *filename,
                                 const char *mode,
                                 struct riffr_chunk_type *form);
@@ -43,6 +65,7 @@ extern int riffr_read_data(struct riffr *handle,
                            const char *format,
                            size_t length,
                            void *buffer);
+extern const char *riffr_filename(const struct riffr *handle);
 
 #define riffr_type_str(form) ((form).str)
 

--- a/riffr_filename.c
+++ b/riffr_filename.c
@@ -1,0 +1,14 @@
+/*
+   riffr_filename.c
+
+   Copyright (c) 2021 by Daniel Kelley
+
+*/
+
+#include "riffr.h"
+#include "riffr_internal.h"
+
+const char *riffr_filename(const struct riffr *handle)
+{
+    return handle->filename;
+}

--- a/riffr_internal.h
+++ b/riffr_internal.h
@@ -19,6 +19,7 @@
 /* handle */
 struct riffr {
     struct riffr_chunk_type form;
+    const char *filename;
     FILE *f;
     uint16_t (*r16)(uint16_t);
     uint32_t (*r32)(uint32_t);

--- a/riffr_open.c
+++ b/riffr_open.c
@@ -26,6 +26,7 @@ static uint32_t riffr_le32toh(uint32_t data)
 static int riffr_valid(struct riffr *handle)
 {
     int err = -1;
+    int rc = 0;
     struct riffr_chunk_header riff_header;
     uint32_t form_id;
 
@@ -52,11 +53,12 @@ static int riffr_valid(struct riffr *handle)
             break;
         }
 
-        err = riffr_read_data(handle,
-                              "D",
-                              sizeof(form_id),
-                              &form_id);
-        if (err) {
+        rc = riffr_read_data(handle,
+                             "D",
+                             sizeof(form_id),
+                             &form_id);
+        if (rc < 0) {
+            err = rc;
             break;
         }
 
@@ -75,6 +77,7 @@ static int riffr_open_internal(struct riffr *handle,
     int err = -1;
 
     handle->f = fopen(filename, mode);
+    handle->filename = filename;
     if (handle->f) {
         err = riffr_valid(handle);
     } else {

--- a/riffr_read_chunk_header.c
+++ b/riffr_read_chunk_header.c
@@ -13,12 +13,18 @@ int riffr_read_chunk_header(struct riffr *handle,
 
 {
     int err = -1;
+    int rc;
 
     do {
         if (!handle || !header) {
             break;
         }
-        err = riffr_read_data(handle, "DD", sizeof(*header), header);
+        rc = riffr_read_data(handle, "DD", sizeof(*header), header);
+        if (rc < 0) {
+            err = rc;
+        } else if (rc > 0) {
+            err = 0;
+        }
     } while (0);
 
     return err;

--- a/riffr_read_data.c
+++ b/riffr_read_data.c
@@ -11,7 +11,8 @@
 
 static int riffr_read_dword_internal(struct riffr *handle,
                                      size_t *length,
-                                     void **buffer)
+                                     void **buffer,
+                                    size_t *actual)
 {
     int err = -1;
     uint32_t data;
@@ -21,14 +22,86 @@ static int riffr_read_dword_internal(struct riffr *handle,
 
     if (*length >= datalen) {
         num = fread(&data, 1, datalen, handle->f);
-        err = (num != datalen);
+        err = (num != datalen) ? -1 : 0;
         if (!err) {
             *length = *length - datalen;
             *out++ = handle->r32(data);
             *buffer = out;
+            *actual += datalen;
         }
+    } else {
+        err = 0;
     }
 
+    return err;
+}
+
+static int riffr_read_word_internal(struct riffr *handle,
+                                    size_t *length,
+                                    void **buffer,
+                                    size_t *actual)
+{
+    int err = -1;
+    uint16_t data;
+    size_t datalen = sizeof(data);
+    size_t num;
+    uint16_t *out = *(uint16_t **)buffer;
+
+    if (*length >= datalen) {
+        num = fread(&data, 1, datalen, handle->f);
+        err = (num != datalen) ? -1 : 0;
+        if (!err) {
+            *length = *length - datalen;
+            *out++ = handle->r16(data);
+            *buffer = out;
+            *actual += datalen;
+        }
+    } else {
+        err = 0;
+    }
+
+    return err;
+}
+
+static int riffr_read_char_internal(struct riffr *handle,
+                                    size_t *length,
+                                    void **buffer,
+                                    size_t *actual)
+{
+    int err = -1;
+    size_t num;
+    uint8_t *out = *(uint8_t **)buffer;
+    size_t datalen = sizeof(*out);
+
+    if (*length >= datalen) {
+        num = fread(out, 1, datalen, handle->f);
+        err = (num != datalen) ? -1 : 0;
+        if (!err) {
+            *length = *length - datalen;
+            *buffer = ++out;
+            *actual += datalen;
+        }
+    } else {
+        err = 0;
+    }
+
+    return err;
+}
+
+static int riffr_read_guid_internal(struct riffr *handle,
+                                    size_t *length,
+                                    void **buffer,
+                                    size_t *actual)
+{
+    int err = -1;
+    int i;
+
+    for (i=0; i<RIFFR_WAVE_FMT_GUID_LEN; i++) {
+        err = riffr_read_char_internal(handle, length, buffer, actual);
+        if (err) {
+            break;
+        }
+    }
     return err;
 }
 
@@ -39,20 +112,35 @@ static int riffr_read_data_internal(struct riffr *handle,
 {
     int err = -1;
     int c;
+    size_t actual = 0;
 
     while ((c = *format++)) {
         switch (c) {
         case 'D':
-            err = riffr_read_dword_internal(handle, &length, &buffer);
+            err = riffr_read_dword_internal(handle, &length, &buffer, &actual);
+            break;
+        case 'W':
+            err = riffr_read_word_internal(handle, &length, &buffer, &actual);
+            break;
+        case 'G':
+            err = riffr_read_guid_internal(handle, &length, &buffer, &actual);
+            break;
+        case 'C':
+            err = riffr_read_char_internal(handle, &length, &buffer, &actual);
             break;
         default:
+            err = -1;
+            break;
+        }
+        if (err) {
             break;
         }
     }
 
-    return err;
+    return err ? err : (int)actual;
 }
 
+/* return: <0 error other bytes read. */
 int riffr_read_data(struct riffr *handle,
                     const char *format,
                     size_t length,


### PR DESCRIPTION
Support WAVE fmt header
Support WORD and GUID decoding
riffr_read_data() returns +length or -error